### PR TITLE
Fixes #43 - non-pingable server isn't saved in probe.conf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,6 +295,8 @@ class Configure(_install):
                                              + Bcolor.END)).rstrip().lstrip()
                 if not go_on.lower() == "y":
                     return self.get_config_ip()
+                else:
+                    return tmp_ip
             else:
                 print(Bcolor.GREEN + "PRTG Server can be reached. Continuing..." + Bcolor.END)
                 return tmp_ip


### PR DESCRIPTION
If a provided hostname or IP address doesn't respond to ping, the option is given to continue but the value is never returned from get_config_ip() and thus not saved to the probe.conf